### PR TITLE
Fix PHP 8.4 deprecation notices generated on cache clear

### DIFF
--- a/src/Turnstile/Turnstile.php
+++ b/src/Turnstile/Turnstile.php
@@ -69,10 +69,10 @@ class Turnstile {
   /**
    * Constructor.
    */
-  public function __construct($site_key, $secret_key, $attributes = array(), RequestMethod $requestMethod = NULL) {
+  public function __construct($site_key, $secret_key, $attributes = array(), ?RequestMethod $requestMethod = NULL) {
     $this->siteKey = $site_key;
     $this->secretKey = $secret_key;
-    $this->requestMethod = $requestMethod;
+    $this->requestMethod = $requestMethod ?: new BackdropPost();
 
     if (!empty($attributes) && is_array($attributes)) {
       foreach ($attributes as $name => $attribute) {


### PR DESCRIPTION
See issue #20 for details about this pull request and issue.  